### PR TITLE
Mirror submodules to GitHub

### DIFF
--- a/.github/workflows/mirror-submodule-sources.yml
+++ b/.github/workflows/mirror-submodule-sources.yml
@@ -12,7 +12,7 @@ name: Mirror submodule sources to GitHub
 
 on:
   schedule:
-    - cron: '17 */6 * * *'   # every six hours, off the hour
+    - cron: '*/5 * * * *'   # every 5 minutes (GitHub cron minimum)
   workflow_dispatch:
 
 concurrency:
@@ -43,15 +43,26 @@ jobs:
             exit 1
           fi
 
+          src_url='${{ matrix.source }}'
+          dst_url="https://github.com/${{ matrix.target }}.git"
+
+          # Cheap check: if heads and tags already match, no work to do.
+          src_refs=$(git ls-remote "$src_url" 'refs/heads/*' 'refs/tags/*' | sort)
+          dst_refs=$(git ls-remote "$dst_url" 'refs/heads/*' 'refs/tags/*' | sort)
+          if [ "$src_refs" = "$dst_refs" ]; then
+            echo "Already in sync; nothing to push."
+            exit 0
+          fi
+
           workdir=$(mktemp -d)
           trap 'rm -rf "$workdir"' EXIT
 
-          echo "Cloning ${{ matrix.source }} ..."
-          git clone --mirror "${{ matrix.source }}" "$workdir/repo.git"
+          echo "Cloning $src_url ..."
+          git clone --mirror "$src_url" "$workdir/repo.git"
 
-          echo "Pushing to https://github.com/${{ matrix.target }}.git ..."
+          echo "Pushing to $dst_url ..."
           git -C "$workdir/repo.git" push --force --prune \
-            "https://x-access-token:${MIRROR_TOKEN}@github.com/${{ matrix.target }}.git" \
+            "https://x-access-token:${MIRROR_TOKEN}@${dst_url#https://}" \
             'refs/heads/*:refs/heads/*' \
             'refs/tags/*:refs/tags/*'
 

--- a/.github/workflows/mirror-submodule-sources.yml
+++ b/.github/workflows/mirror-submodule-sources.yml
@@ -1,0 +1,58 @@
+name: Mirror submodule sources to GitHub
+
+# Keeps the GitHub mirrors of our submodule sources in sync with the Codeberg
+# originals. Runs on a schedule and on demand.
+#
+# Requires a repo secret named MIRROR_TOKEN: a Personal Access Token (or
+# fine-grained token) with contents:write on:
+#   - github.com/tenacityteam/vcpkg
+#   - github.com/tenacityteam/libnyquist
+# The default GITHUB_TOKEN only has access to this repo, which is why a
+# separate token is needed.
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'   # every six hours, off the hour
+  workflow_dispatch:
+
+concurrency:
+  group: mirror-submodule-sources
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: vcpkg
+            source: https://codeberg.org/tenacityteam/vcpkg.git
+            target: tenacityteam/vcpkg
+          - name: libnyquist
+            source: https://codeberg.org/tenacityteam/libnyquist.git
+            target: tenacityteam/libnyquist
+    steps:
+      - name: Mirror ${{ matrix.name }}
+        env:
+          MIRROR_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MIRROR_TOKEN" ]; then
+            echo "MIRROR_TOKEN secret is not set; cannot push to GitHub mirror." >&2
+            exit 1
+          fi
+
+          workdir=$(mktemp -d)
+          trap 'rm -rf "$workdir"' EXIT
+
+          echo "Cloning ${{ matrix.source }} ..."
+          git clone --mirror "${{ matrix.source }}" "$workdir/repo.git"
+
+          echo "Pushing to https://github.com/${{ matrix.target }}.git ..."
+          git -C "$workdir/repo.git" push --force --prune \
+            "https://x-access-token:${MIRROR_TOKEN}@github.com/${{ matrix.target }}.git" \
+            'refs/heads/*:refs/heads/*' \
+            'refs/tags/*:refs/tags/*'
+
+          echo "Done."

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = https://codeberg.org/tenacityteam/vcpkg.git
+	url = https://github.com/tenacityteam/vcpkg.git
 	branch = tenacity
 [submodule "lib-src/libnyquist"]
 	path = lib-src/libnyquist
-	url = https://codeberg.org/tenacityteam/libnyquist
+	url = https://github.com/tenacityteam/libnyquist.git
 [submodule "lib-src/pffft"]
 	path = lib-src/pffft
 	url = https://github.com/marton78/pffft


### PR DESCRIPTION
I want to point our git submodules all at github so that githubs UI works correctly for our security scan results. Currently we have 3 github submodules and 2 codeberg submodules, so I made a mirror repo for each of the two submodules that need to be changed and this PR will point the submodules at the github mirror instead of Codeberg. I also wrote a little workflow/webhook with a token to keep the submodules in sync with checks every 5 minutes and a no-op if all is synced. Since submodules don't get updated super often, having to wait 5 minutes is a small price compared to not being able to see what code has been identified as vulnerable because the preview wont show for a codeberg submodule. This makes fixing all the vulnerabilities identified in our recent security scans much easier since now the code previews will work.